### PR TITLE
Updated x_ite urls.

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -12,13 +12,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="./src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
 <style >
 html, body {

--- a/tests/addAndRemoveNode.xhtml
+++ b/tests/addAndRemoveNode.xhtml
@@ -13,13 +13,13 @@
 		}
 		</style>
 	        <script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 </head>
        
 <body>

--- a/tests/cycle.xhtml
+++ b/tests/cycle.xhtml
@@ -5,13 +5,13 @@
       <meta charset="utf-8"/>
 
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 		<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick.css"/>
 		
       <style>

--- a/tests/dev/inline/inlineScene.xhtml
+++ b/tests/dev/inline/inlineScene.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 
 <style>

--- a/tests/dev/inline/internalScene.xhtml
+++ b/tests/dev/inline/internalScene.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 
 <style>

--- a/tests/fanOutRoute.xhtml
+++ b/tests/fanOutRoute.xhtml
@@ -6,13 +6,13 @@
 		<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 		<title>Multiple animations with a single TimeSensor and fanOut, add/remove ROUTEs</title>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	</head>
 
 <body>

--- a/tests/gears_proto.xhtml
+++ b/tests/gears_proto.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style>
 html, body {

--- a/tests/html5/cobweb_integration2.html
+++ b/tests/html5/cobweb_integration2.html
@@ -3,13 +3,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>X3D DOM integration</title>
 	<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 	</script>
 	<script type="text/javascript" 
 		src="../../src/x_ite_dom.js">
 	</script>
 	<link rel="stylesheet" type="text/css"
-		href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+		href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
     <style >
 X3DCanvas {

--- a/tests/html5/gears_proto.html
+++ b/tests/html5/gears_proto.html
@@ -10,13 +10,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style>
 html, body {

--- a/tests/html5/html5.html
+++ b/tests/html5/html5.html
@@ -9,13 +9,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
 <style >
 html, body {

--- a/tests/html5/inline_Mushroom.html
+++ b/tests/html5/inline_Mushroom.html
@@ -10,13 +10,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style>
 html, body {

--- a/tests/html5/inlinev2.html
+++ b/tests/html5/inlinev2.html
@@ -10,13 +10,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 
 <style>

--- a/tests/html5/interactiveTransformations.html
+++ b/tests/html5/interactiveTransformations.html
@@ -9,13 +9,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
 <style>
 html, body {

--- a/tests/html5/jqueryui_adopted.html
+++ b/tests/html5/jqueryui_adopted.html
@@ -6,13 +6,13 @@
     <title>JQuery Manipulation</title>
     	
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
   <style>
   html, body {

--- a/tests/html5/rosetta_xite.xhtml
+++ b/tests/html5/rosetta_xite.xhtml
@@ -4,7 +4,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <title>X_ITE X3D/XHTML/SVG Example</title>
         <link rel="stylesheet" type="text/css" href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
-        <script type="text/javascript" src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.min.js"></script>
+        <script type="text/javascript" src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js"></script>
         <script type="text/javascript" src="https://raw.githack.com/andreasplesch/x_ite_dom/master/release/x_ite_dom.1.3.js"></script>
         <style >
     X3DCanvas {

--- a/tests/html5/x3d_d3.html
+++ b/tests/html5/x3d_d3.html
@@ -10,13 +10,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 		<script src="https://d3js.org/d3.v4.min.js"></script>
 			
 <style >

--- a/tests/html5/x3d_integration.html
+++ b/tests/html5/x3d_integration.html
@@ -3,13 +3,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>dom integration</title> 
 	<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 	</script>
 	<script type="text/javascript" 
 		src="../../src/x_ite_dom.js">
 	</script>
 	<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
     <style >
 X3DCanvas {
 	width: 500px;

--- a/tests/html5/x3d_integration2.html
+++ b/tests/html5/x3d_integration2.html
@@ -4,13 +4,13 @@
     <title>X3D DOM integration</title>
     
 	<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 	</script>
 	<script type="text/javascript" 
 		src="../../src/x_ite_dom.js">
 	</script>
 	<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
     <style >
 X3DCanvas {

--- a/tests/html5/x3d_script.html
+++ b/tests/html5/x3d_script.html
@@ -9,13 +9,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 		<script src="https://d3js.org/d3.v4.min.js"></script>
 		

--- a/tests/html5/x3d_script2.html
+++ b/tests/html5/x3d_script2.html
@@ -9,13 +9,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 		<script src="https://d3js.org/d3.v4.min.js"></script>
 		

--- a/tests/importDoc.xhtml
+++ b/tests/importDoc.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 		
 <style id="jsbin-css">
 html, body {

--- a/tests/importDocument.xhtml
+++ b/tests/importDocument.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 		
 <style id="jsbin-css">
 html, body {

--- a/tests/inline_Mushrooms.xhtml
+++ b/tests/inline_Mushrooms.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style>
 html, body {

--- a/tests/inline_dom.xhtml
+++ b/tests/inline_dom.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style>
 html, body {

--- a/tests/inline_in_inline.xhtml
+++ b/tests/inline_in_inline.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style >
 html, body {

--- a/tests/inline_proto.xhtml
+++ b/tests/inline_proto.xhtml
@@ -10,13 +10,13 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style>
 html, body {

--- a/tests/inline_reflection/dom_inlineReflection.xhtml
+++ b/tests/inline_reflection/dom_inlineReflection.xhtml
@@ -7,13 +7,13 @@
 		<title>Inline HTML Reflection</title>
 		
 		<script type="text/javascript" 
-			src="https://cdn.rawgit.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://cdn.rawgit.com/create3000/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 		<style>
 			X3DCanvas {

--- a/tests/inline_route.xhtml
+++ b/tests/inline_route.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
   <style>
   X3DCanvas {

--- a/tests/inlinev2.xhtml
+++ b/tests/inlinev2.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 
 <style>

--- a/tests/interactiveTransformations.xhtml
+++ b/tests/interactiveTransformations.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
 <style>
 html, body {

--- a/tests/jqueryui_adopt.xhtml
+++ b/tests/jqueryui_adopt.xhtml
@@ -10,13 +10,13 @@
 	<script type="text/javascript" src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
 	<script>$$ = jQuery.noConflict();</script>
 	<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 	</script>
 	<script type="text/javascript" 
 		src="../src/x_ite_dom.js">
 	</script>
 	<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
   <style>
   html, body {
   	margin: 0px;

--- a/tests/output_events.xhtml
+++ b/tests/output_events.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
 <style>
 html, body {

--- a/tests/removeAddMaterial.xhtml
+++ b/tests/removeAddMaterial.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 <style>
 

--- a/tests/test_alphax_ite.xhtml
+++ b/tests/test_alphax_ite.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/master/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
 <style>
 html, body {

--- a/tests/x3d_d3.xhtml
+++ b/tests/x3d_d3.xhtml
@@ -10,14 +10,14 @@
 		<meta http-equiv="Expires" content="0"/>
 		<meta charset="utf-8"/>
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<script type="text/javascript" src="https://d3js.org/d3.v4.min.js"></script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 		
 <style >
 html, body {

--- a/tests/x3d_integration2.xhtml
+++ b/tests/x3d_integration2.xhtml
@@ -4,13 +4,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>X3D DOM integration</title>
 	<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 	</script>
 	<script type="text/javascript" 
 		src="../src/x_ite_dom.js">
 	</script>
 	<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 
     <style>
 X3DCanvas {

--- a/tests/x3d_multiview.xhtml
+++ b/tests/x3d_multiview.xhtml
@@ -7,13 +7,13 @@
 		<title>Multi-View: Multiple X3D scenes in a single XHTML document</title>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 		
 		<style>
 			X3DCanvas {

--- a/tests/x3d_script.xhtml
+++ b/tests/x3d_script.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 		<script src="https://d3js.org/d3.v4.min.js"></script>
 		

--- a/tests/x3d_script2.xhtml
+++ b/tests/x3d_script2.xhtml
@@ -11,13 +11,13 @@
 		<meta charset="utf-8"/>
 		
 		<script type="text/javascript" 
-			src="https://rawcdn.githack.com/create3000/x_ite/latest/dist/x_ite.js">
+			src="https://create3000.github.io/code/x_ite/latest/dist/x_ite.js">
 		</script>
 		<script type="text/javascript" 
 			src="../src/x_ite_dom.js">
 		</script>
 		<link rel="stylesheet" type="text/css"
-			href="https://code.create3000.de/x_ite/latest/dist/x_ite.css"/>
+			href="https://create3000.github.io/code/x_ite/latest/dist/x_ite.css"/>
 	
 		<script src="https://d3js.org/d3.v4.min.js"></script>
 		


### PR DESCRIPTION
Since X_ITE is now hosted on GitHub and create3000.de will be shutdown on May 2022 I have updated the urls in the tests.

New website is now https://create3000.github.io/x_ite/ :)

Best regards,
Holger